### PR TITLE
Feature/7682 use different registrations for client and api

### DIFF
--- a/src/ClientApp/app.js
+++ b/src/ClientApp/app.js
@@ -6,6 +6,7 @@
         tenant: '<Azure AD tenant name>',
         clientId: '<application id>',
         postLogoutRedirectUri: window.location.origin,
+        apiId: '<api application id>',
         apiUrl: '<URL of the API Management API endpoint>'
     };
     var authContext = new AuthenticationContext(config);
@@ -69,7 +70,7 @@
         $loading.show();
 
         // Acquire Token for Backend
-        authContext.acquireToken(authContext.config.clientId, function (error, token) {
+        authContext.acquireToken(authContext.config.apiId, function (error, token) {
 
             // Handle ADAL Error
             if (error || !token) {

--- a/src/ClientApp/readme.md
+++ b/src/ClientApp/readme.md
@@ -14,27 +14,16 @@ Register the application
 2. Enter a friendly name for the application, for example 'Fabrikam', and select 'Web Application and/or Web API' as the Application Type. For the sign-on URL, you can enter `https://localhost/`. Click **Create** to create the application.
 3. Copy the Application ID. You will need this later.
 4. Click **Settings** > **Required Permissions**, and click the **Grant Permissions** button in the top bar. Click **Yes** to confirm.
+5. Click the **Add** button in the top bar. 
+6. Click **Select an API**, search the principal name of the DroneStatus API, and click **Select**.
+7. Click **Select permissions**, click the entry **Access [DroneStatus API]** in the **Delegated Permissions** section, and click **Select**.
+8. Click the **Done** button.
 
 Update the manifest
 
 1. From the application blade, click **Manifest** to open the inline manifest editor.
 2. Search for the `oauth2AllowImplicitFlow` property. Change the value to `true`. This setting enables implicit grant flow, which is disabled by default.
-3. Define a "GetStatus" role for the app by adding the following entry in the "appRoles" array in the manifest (replacing the placeholder GUID with a new GUID)
-
-    ```json
-    {
-    "allowedMemberTypes": [
-        "User"
-    ],
-    "description":"Access to device status",
-    "displayName":"Get Device Status",
-    "id": "[generate a new GUID]",
-    "isEnabled":true,
-    "value":"GetStatus"
-    }
-    ```
-
-4. Click **Save**.
+3. Click **Save**.
 
 Get the issuer URL
 
@@ -43,21 +32,12 @@ Get the issuer URL
 3. Open a new browser window and navigate to the URL. In the XML document, find the **EntityDescriptor** element.
 4. Copy the value of the **entityID** attribute. This attribute is the Issuer URL.
 
-Assign users
-
-1. Go back to the blade for your Azure AD tenant. Click **Enterprise Applications** and then click on the application name.
-2. Click **Users and groups**.
-3. Click **Users**, select a user, and click **Select**.
-
-    > Note: If you define more than one App role in the manifest, you can select the user's role. In this case, there is only one role, so the option is grayed out.
-
-4. Click **Assign**.
-
 At this point you should have the following values, which you will need later:
 
 - Azure AD tenant name
 - Azure AD directory ID
 - Application ID
+- API Application ID
 - Issuer URL
 
 ## Update the client app 
@@ -65,7 +45,8 @@ At this point you should have the following values, which you will need later:
 1. Open the file src/ClientApp/app.js and locate the setup of the window.config.
 2. Update the **tenant** value with the Azure AD tenant name
 3. Update the **clientId** value with the Application ID
-4. Update the **apiUrl** value with the URL for the APIM gateway URL 
+4. Update the **apiId** value with the API Application ID
+4. Update the **apiUrl** value with the URL for the APIM gateway URL for v1
 
 ## Deploy to Azure Storage static website hosting
 
@@ -89,48 +70,3 @@ See [Static website hosting in Azure Storage](https://docs.microsoft.com/azure/s
 4. Clieck **Settings**/
 5. Under **Reply URL**, add the primary endpoint URL for the website, from the previous step.
 6. Click **Save**.
-
-## Configure Azure AD authentication in the Function App
-
-1. In the Azure Portal, navigate to your Function App.
-2. Select **Platform features**
-3. Click **Authentication / Authorization**
-4. Toggle App Service Authentication to **On**.
-5. Click **Azure Active Directory**.
-6. In the **Azure Active Directory Settings** blade, select **Advanced**.
-7. Under **Client ID**, paste in the Application ID.
-8. Under **Issuer Url**, paste in the issuer URL.
-9. Click **OK**.
-
-## Configure the API Management policies
-
-1. In the Azure Portal, navigate to your API Management instance.
-2. Click **APIs** and select the GetStatus API.
-3. Click **Design**.
-4. Click the **&lt;/&gt;** icon next to **Policies**.
-5. Paste in the following policy definitions:
-
-    ```xml
-    <inbound>
-        <base />
-        <cors allow-credentials="true">
-            <allowed-origins>
-                <origin>[Website URL]</origin>
-            </allowed-origins>
-            <allowed-methods>
-                <method>GET</method>
-            </allowed-methods>
-            <allowed-headers>
-                <header>*</header>
-            </allowed-headers>
-        </cors>
-        <validate-jwt header-name="Authorization" failed-validation-httpcode="401" failed-validation-error-message="Unauthorized. Access token is missing or invalid.">
-            <openid-config url="https://login.microsoftonline.com/[Azure AD directory ID]/.well-known/openid-configuration" />
-            <required-claims>
-                <claim name="aud">
-                    <value>[Application ID]</value>
-                </claim>
-            </required-claims>
-        </validate-jwt>
-    </inbound>
-    ```

--- a/src/azuredeploy-backend-functionapps-v2.json
+++ b/src/azuredeploy-backend-functionapps-v2.json
@@ -6,7 +6,7 @@
             "type": "string",
             "maxLength": 6,
             "metadata": {
-                "description": "The name for the function app. It must only contain characters and numbers, and be 11 chars long max."
+                "description": "The name for the function app. It must only contain characters and numbers, and be 6 chars long max."
             }
         },
         "cosmosDatabaseAccount": {

--- a/src/azuredeploy-backend-functionapps.json
+++ b/src/azuredeploy-backend-functionapps.json
@@ -4,9 +4,9 @@
     "parameters": {
         "appName": {
             "type": "string",
-            "maxLength": 8,
+            "maxLength": 6,
             "metadata": {
-                "description": "The name for the function app. It must only contain characters and numbers, and be 11 chars long max."
+                "description": "The name for the function app. It must only contain characters and numbers, and be 6 chars long max."
             }
         },
         "storageAccountType": {

--- a/src/readme-backend-functionapps-v2.md
+++ b/src/readme-backend-functionapps-v2.md
@@ -78,3 +78,17 @@ export FUNCTIONAPP_KEY_V2=<function-key>
 > rovokable specific key.
 > By the time writing this, azure function key management using ARM is problematic.
 > For more information please refer to https://github.com/Azure/azure-functions-host/wiki/Changes-to-Key-Management-in-Functions-V2#arm-impact
+
+## step 7
+
+1. In the Azure Portal, navigate to the drone status v2 function.
+2. Select **Platform features**
+3. Click **Authentication / Authorization**
+4. Toggle App Service Authentication to **On**.
+5. Click **Azure Active Directory**.
+6. In the **Azure Active Directory Settings** blade, select **Express**, click the default **Select Existing AD App**.
+7. Click **Azure AD App**, select the application created for v1 in the list, and click **OK**.
+7. Click **OK**.
+8. Click **Save**.
+
+> Note: for this example, both versions of the function will represent the same resource so they will share the AAD application id. Tokens retrieved to access the API will work for both versions.

--- a/src/readme-backend-functionapps.md
+++ b/src/readme-backend-functionapps.md
@@ -113,3 +113,45 @@ az functionapp deployment source config-zip \
    -g $RESOURCEGROUP \
    -n ${APPNAME}-dt-funcapp
 ```
+
+## step 9
+
+1. In the Azure Portal, navigate to the drone status function.
+2. Select **Platform features**
+3. Click **Authentication / Authorization**
+4. Toggle App Service Authentication to **On**.
+5. Click **Azure Active Directory**.
+6. In the **Azure Active Directory Settings** blade, select **Express**, leave the default **Create New AD App**.
+7. Click **OK**.
+8. Click **Save**.
+
+## step 10
+
+1. In the Azure Portal, navigate to your Azure AD tenant.
+2. Click on **App registrations**.
+3. View all applications, and select the drone API application.
+4. From the application blade, click **Manifest** to open the inline manifest editor.
+5. Define a "GetStatus" role for the app by adding the following entry in the "appRoles" array in the manifest (replacing the placeholder GUID with a new GUID)
+
+    ```json
+    {
+    "allowedMemberTypes": [ "User" ],
+    "description":"Access to device status",
+    "displayName":"Get Device Status",
+    "id": "[generate a new GUID]",
+    "isEnabled":true,
+    "value":"GetStatus"
+    }
+    ```
+6. Click **Save**.
+
+## step 11
+
+1. In the Azure Portal, navigate to your Azure AD tenant.
+2. Click on **Enterprise Applications** and then click on the Drone Status application name.
+2. Click **Users and groups**.
+3. Click **Users**, select a user, and click **Select**.
+
+    > Note: If you define more than one App role in the manifest, you can select the user's role. In this case, there is only one role, so the option is grayed out.
+
+4. Click **Assign**.

--- a/src/readme.md
+++ b/src/readme.md
@@ -79,3 +79,39 @@ export APIM_GATEWAY_URL=$(az group deployment show \
 curl GET "${APIM_GATEWAY_URL}/api/v1/dronestatus/{deviceid}" && \
 curl GET "${APIM_GATEWAY_URL}/api/v2/dronestatus/{deviceid}"
 ```
+
+## step 9
+
+1. In the Azure Portal, navigate to your API Management instance.
+2. Click **APIs** and select the GetStatus API.
+3. Click v1
+4. Click **Design**.
+5. Click the **&lt;/&gt;** icon next to **Policies**.
+6. Paste in the following policy definitions:
+
+    ```xml
+    <inbound>
+        <base />
+        <cors allow-credentials="true">
+            <allowed-origins>
+                <origin>[Client website URL]</origin>
+            </allowed-origins>
+            <allowed-methods>
+                <method>GET</method>
+            </allowed-methods>
+            <allowed-headers>
+                <header>*</header>
+            </allowed-headers>
+        </cors>
+        <validate-jwt header-name="Authorization" failed-validation-httpcode="401" failed-validation-error-message="Unauthorized. Access token is missing or invalid.">
+            <openid-config url="https://login.microsoftonline.com/[Azure AD directory ID]/.well-known/openid-configuration" />
+            <required-claims>
+                <claim name="aud">
+                    <value>[API Application ID]</value>
+                </claim>
+            </required-claims>
+        </validate-jwt>
+    </inbound>
+    ```
+7. Click **Save**.
+8. Repeat for v2


### PR DESCRIPTION
Update the client SPA to use a different resource ID for accessing the API
Update the md files with the new instructions, reorganizing them to move content to the most appropriate location. In particular, manifest editing and role assignment for the API is described in the API deployment docs, and API Management instructions are moved to the matching file.

Also minor tweaks to consolidate ARM templates and fix typos

Fixes #8