### PR TITLE
Fix required name length comment

### DIFF
--- a/src/readme.md
+++ b/src/readme.md
@@ -20,7 +20,7 @@ Export the following environment variables:
 ``` bash
 export LOCATION=<location>
 export RESOURCEGROUP=<resource-group>
-export APPNAME=<functionapp-name> # Cannot be more than 8 characters
+export APPNAME=<functionapp-name> # Cannot be more than 6 characters
 export APP_INSIGHTS_LOCATION=<application-insights-location>
 export COSMOSDB_DATABASE_NAME=${APPNAME}-db
 export COSMOSDB_DATABASE_COL=${APPNAME}-col


### PR DESCRIPTION
App name must be 6 or less characters as shown below:

$ export APPNAME=servtest

...

$ az group deployment create ...

...

Azure Error: InvalidTemplate
Message: Deployment template validation failed: 'The provided value for the template parameter 'appName' at line '1' and column '179' is not valid. Length of the value should be less than or equal to '6'. Please see https://aka.ms/arm-template/#parameters for usage details.'.