### PR TITLE
Use DI to inject serializer

### DIFF
--- a/src/DroneTelemetry/DroneTelemetryFunctionApp/DroneTelemetryFunctionApp.csproj
+++ b/src/DroneTelemetry/DroneTelemetryFunctionApp/DroneTelemetryFunctionApp.csproj
@@ -5,10 +5,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.8.0-beta1" />
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.0" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.22" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.4.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="3.0.5" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.6" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.28" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\TelemetrySerialization\Serverless.Serialization\Serverless.Serialization.csproj" />

--- a/src/DroneTelemetry/DroneTelemetryFunctionApp/IStateChangeProcessor.cs
+++ b/src/DroneTelemetry/DroneTelemetryFunctionApp/IStateChangeProcessor.cs
@@ -1,0 +1,13 @@
+using Microsoft.Azure.Documents;
+using Microsoft.Azure.Documents.Client;
+using Microsoft.Extensions.Logging;
+using System.Threading.Tasks;
+
+namespace DroneTelemetryFunctionApp
+{
+    public interface IStateChangeProcessor
+    {
+        Task<ResourceResponse<Document>> UpdateState(DeviceState source, ILogger log);
+    }
+}
+

--- a/src/DroneTelemetry/DroneTelemetryFunctionApp/ITelemetryProcessor.cs
+++ b/src/DroneTelemetry/DroneTelemetryFunctionApp/ITelemetryProcessor.cs
@@ -1,0 +1,9 @@
+using Microsoft.Extensions.Logging;
+
+namespace DroneTelemetryFunctionApp
+{
+    public interface ITelemetryProcessor
+    {
+        DeviceState Deserialize(byte[] payload, ILogger log);
+    }
+}

--- a/src/DroneTelemetry/DroneTelemetryFunctionApp/Startup.cs
+++ b/src/DroneTelemetry/DroneTelemetryFunctionApp/Startup.cs
@@ -3,11 +3,11 @@ using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Azure.Documents;
 using Microsoft.Azure.Documents.Client;
 using Microsoft.Azure.Functions.Extensions.DependencyInjection;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using Serverless.Serialization;
 using Serverless.Serialization.Models;
-using Microsoft.Extensions.Configuration;
 
 [assembly: FunctionsStartup(typeof(DroneTelemetryFunctionApp.Startup))]
 

--- a/src/DroneTelemetry/DroneTelemetryFunctionApp/Startup.cs
+++ b/src/DroneTelemetry/DroneTelemetryFunctionApp/Startup.cs
@@ -1,0 +1,17 @@
+using Microsoft.Azure.Functions.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+using Serverless.Serialization;
+using Serverless.Serialization.Models;
+
+[assembly: FunctionsStartup(typeof(DroneTelemetryFunctionApp.Startup))]
+
+namespace DroneTelemetryFunctionApp
+{
+    public class Startup : FunctionsStartup
+    {
+        public override void Configure(IFunctionsHostBuilder builder)
+        {
+            builder.Services.AddSingleton<ITelemetrySerializer<DroneState>, TelemetrySerializer<DroneState>>();
+        }
+    }
+}

--- a/src/DroneTelemetry/DroneTelemetryFunctionApp/Startup.cs
+++ b/src/DroneTelemetry/DroneTelemetryFunctionApp/Startup.cs
@@ -1,7 +1,13 @@
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.Azure.Documents;
+using Microsoft.Azure.Documents.Client;
 using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection;
+using System;
 using Serverless.Serialization;
 using Serverless.Serialization.Models;
+using Microsoft.Extensions.Configuration;
 
 [assembly: FunctionsStartup(typeof(DroneTelemetryFunctionApp.Startup))]
 
@@ -11,7 +17,25 @@ namespace DroneTelemetryFunctionApp
     {
         public override void Configure(IFunctionsHostBuilder builder)
         {
-            builder.Services.AddSingleton<ITelemetrySerializer<DroneState>, TelemetrySerializer<DroneState>>();
+            var config = builder.Services.BuildServiceProvider().GetService<IConfiguration>();
+
+            builder.Services.AddTransient<ITelemetrySerializer<DroneState>, TelemetrySerializer<DroneState>>();
+            builder.Services.AddTransient<ITelemetryProcessor, TelemetryProcessor>();
+            builder.Services.AddTransient<IStateChangeProcessor>(ctx =>
+            {
+                var client = ctx.GetService<IDocumentClient>();
+                return new StateChangeProcessor(
+                    client, 
+                    config.GetValue<string>("COSMOSDB_DATABASE_NAME"), 
+                    config.GetValue<string>("COSMOSDB_DATABASE_COL"));
+            });
+
+            var cosmosDBEndpoint = config.GetValue<string>("CosmosDBEndpoint");
+            var cosmosDBKey = config.GetValue<string>("CosmosDBKey");
+            builder.Services.AddSingleton<IDocumentClient>(new DocumentClient(new Uri(cosmosDBEndpoint), cosmosDBKey));
+
+            var key = TelemetryConfiguration.Active.InstrumentationKey = config.GetValue<string>("APPINSIGHTS_INSTRUMENTATIONKEY");
+            builder.Services.AddSingleton<TelemetryClient>(new TelemetryClient() { InstrumentationKey = key });
         }
     }
 }

--- a/src/DroneTelemetry/DroneTelemetryFunctionApp/StateChangeProcessor.cs
+++ b/src/DroneTelemetry/DroneTelemetryFunctionApp/StateChangeProcessor.cs
@@ -1,27 +1,24 @@
 ﻿using Microsoft.Azure.Documents;
 using Microsoft.Azure.Documents.Client;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using System.Linq;
 using System.Threading.Tasks;
 
+
 namespace DroneTelemetryFunctionApp
 {
-    public interface IStateChangeProcessor
-    {
-        Task<ResourceResponse<Document>> UpdateState(DeviceState source, ILogger log);
-    }
-
     public class StateChangeProcessor : IStateChangeProcessor
     {
         private IDocumentClient client;
         private readonly string cosmosDBDatabase;
         private readonly string cosmosDBCollection;
 
-        public StateChangeProcessor(IDocumentClient client, string cosmosDBDatabase, string cosmosDBCollection)
+        public StateChangeProcessor(IDocumentClient client, IOptions<StateChangeProcessorOptions> options)
         {
             this.client = client;
-            this.cosmosDBDatabase = cosmosDBDatabase;
-            this.cosmosDBCollection = cosmosDBCollection;
+            this.cosmosDBDatabase = options.Value.COSMOSDB_DATABASE_NAME;
+            this.cosmosDBCollection = options.Value.COSMOSDB_DATABASE_COL;
         }
 
         public async Task<ResourceResponse<Document>> UpdateState(DeviceState source, ILogger log)

--- a/src/DroneTelemetry/DroneTelemetryFunctionApp/StateChangeProcessor.cs
+++ b/src/DroneTelemetry/DroneTelemetryFunctionApp/StateChangeProcessor.cs
@@ -6,7 +6,12 @@ using System.Threading.Tasks;
 
 namespace DroneTelemetryFunctionApp
 {
-    public class StateChangeProcessor
+    public interface IStateChangeProcessor
+    {
+        Task<ResourceResponse<Document>> UpdateState(DeviceState source, ILogger log);
+    }
+
+    public class StateChangeProcessor : IStateChangeProcessor
     {
         private IDocumentClient client;
         private readonly string cosmosDBDatabase;
@@ -21,7 +26,7 @@ namespace DroneTelemetryFunctionApp
 
         public async Task<ResourceResponse<Document>> UpdateState(DeviceState source, ILogger log)
         {
-            log.LogInformation("Processing change message for device ID", source.DeviceId);
+            log.LogInformation("Processing change message for device ID {DeviceId}", source.DeviceId);
 
             DeviceState target = null;
 

--- a/src/DroneTelemetry/DroneTelemetryFunctionApp/StateChangeProcessorOptions.cs
+++ b/src/DroneTelemetry/DroneTelemetryFunctionApp/StateChangeProcessorOptions.cs
@@ -1,0 +1,8 @@
+namespace DroneTelemetryFunctionApp
+{
+    public class StateChangeProcessorOptions
+    {
+        public string COSMOSDB_DATABASE_NAME { get; set; }
+        public string COSMOSDB_DATABASE_COL { get; set; }
+    }
+}

--- a/src/DroneTelemetry/DroneTelemetryFunctionApp/TelemetryProcessor.cs
+++ b/src/DroneTelemetry/DroneTelemetryFunctionApp/TelemetryProcessor.cs
@@ -4,12 +4,7 @@ using Serverless.Serialization.Models;
 
 namespace DroneTelemetryFunctionApp
 {
-    public interface ITelemetryProcessor
-    {
-        DeviceState Deserialize(byte[] payload, ILogger log);
-    }
-
-    public class TelemetryProcessor : ITelemetryProcessor
+     public class TelemetryProcessor : ITelemetryProcessor
     {
         private readonly ITelemetrySerializer<DroneState> serializer;
 

--- a/src/DroneTelemetry/DroneTelemetryFunctionApp/TelemetryProcessor.cs
+++ b/src/DroneTelemetry/DroneTelemetryFunctionApp/TelemetryProcessor.cs
@@ -4,7 +4,12 @@ using Serverless.Serialization.Models;
 
 namespace DroneTelemetryFunctionApp
 {
-    public class TelemetryProcessor
+    public interface ITelemetryProcessor
+    {
+        DeviceState Deserialize(byte[] payload, ILogger log);
+    }
+
+    public class TelemetryProcessor : ITelemetryProcessor
     {
         private readonly ITelemetrySerializer<DroneState> serializer;
 
@@ -17,7 +22,7 @@ namespace DroneTelemetryFunctionApp
         {
             DroneState restored = serializer.Deserialize(payload);
 
-            log.LogInformation("Process message for device ID", restored.DeviceId);
+            log.LogInformation("Deserialize message for device ID {DeviceId}", restored.DeviceId);
 
             var deviceState = new DeviceState();
             deviceState.DeviceId = restored.DeviceId;


### PR DESCRIPTION
The latest Functions SDK supports DI. More info [here](https://docs.microsoft.com/en-us/azure/azure-functions/functions-dotnet-dependency-injection)

Per the docs:

> The use of constructor injection means that you should not use static functions if you want to take advantage of dependency injection.

Therefore I changed the function to be a non-static class.